### PR TITLE
Fix web store link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Copy Marker allows you to select some text on page, right click and "Copy Marker
 
 ## Install 
 
-Install it from the [Chrome Web Store](https://chrome.google.com/webstore/detail/jlbhiiaglonlmddaenlicebafcmpcoob/publish-accepted?authuser=0&hl=en) or download and [install manually](http://superuser.com/a/247654/6877)
+Install it from the [Chrome Web Store](https://chrome.google.com/webstore/detail/copy-marker/jlbhiiaglonlmddaenlicebafcmpcoob) or download and [install manually](http://superuser.com/a/247654/6877)
 
 ![](./shot.png)
 


### PR DESCRIPTION
You put the link given to you as the publisher. From our side, we are seeing the "add to chrome" as disabled. This commit fixes it.

## Before
![image](https://user-images.githubusercontent.com/1020565/84599980-1d15b000-ae87-11ea-8f82-5e3a15c2d9ae.png)

## Now
![image](https://user-images.githubusercontent.com/1020565/84599986-29017200-ae87-11ea-8c1d-3e75ccde44d0.png)
